### PR TITLE
Centered Images, Removed Extra Scrollbar

### DIFF
--- a/src/pages/App/App.css
+++ b/src/pages/App/App.css
@@ -3,6 +3,7 @@ body {
   background-position-x: center;
   height: 120vh;
   width: 100vw;
+  overflow: hidden;
 }
 
 #root {

--- a/src/pages/App/components/grid.jsx
+++ b/src/pages/App/components/grid.jsx
@@ -18,7 +18,7 @@ export default function MainGrid(props) {
         
     })
     return (
-        <SimpleGrid columns={2} spacing={10} overflowY='scroll' h="100%" paddingRight={'5px'}>
+        <SimpleGrid columns={2} spacing={10} overflowY='scroll' h="100%" paddingRight={'10%'}>
             {ims}
         </SimpleGrid>
     )

--- a/src/pages/App/components/nav.css
+++ b/src/pages/App/components/nav.css
@@ -11,7 +11,7 @@
     display: flex;
     justify-content: flex-start;
     align-items: flex-start;
-    width: 20%;
+    width: 10%;
     height: 100%;
     padding: 10px;
     padding-right: 0;
@@ -21,7 +21,7 @@
     display: flex;
     flex-direction: column;
     margin-left: 10px;
-    width: 80%;
+    width: 90%;
     height: 100%;
     max-height: fit-content;
 }
@@ -53,7 +53,6 @@
 
 .gallery {
     height: 90%;
-    padding-right: 40px;
     padding-left: 10px;
     margin-top: 20px;
     width: 100%;

--- a/src/pages/App/components/nav.jsx
+++ b/src/pages/App/components/nav.jsx
@@ -75,7 +75,7 @@ export default function Nav(props) {
                     <MenuButton as={Button} rightIcon={<ChevronDownIcon />}>
                         {Title}
                     </MenuButton>
-                    <MenuList className="nav-list" h='100vh' overflowY='scroll'>
+                    <MenuList className="nav-list" h='90vh' overflowY='scroll'>
                         {list}
                     </MenuList>
                 </Menu>


### PR DESCRIPTION
- Hide's secondary vertical (and horizontal) scrollbars. They literally don't do anything anyway except kind of ruin the formatting of the page when you scroll down.
- Fixed overflow of language selection box (there is now a defined height value)
- Changed formatting of page so that images are centered correctly.